### PR TITLE
Upgrade dependencies to support newer Elixirs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,13 @@ language: elixir
 
 matrix:
   include:
-    - otp_release: 18.3
-      elixir: 1.3.1
-    - otp_release: 19.1
-      elixir: 1.4.0
     - otp_release: 20.0
       elixir: 1.5.1
     - otp_release: 20.0
       elixir: 1.6
     - otp_release: 20.0
       elixir: 1.7
+    - otp_release: 22.0
+      elixir: 1.8
 script:
   - mix test --trace

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Barlix.Code39.encode!("BARLIX")
 |> Barlix.PNG.print(file: "/tmp/barcode.png")
 ```
 
-see [documenation](https://hexdocs.pm/barlix/) for more information.
+see [documentation](https://hexdocs.pm/barlix/) for more information.

--- a/lib/barlix/itf.ex
+++ b/lib/barlix/itf.ex
@@ -57,7 +57,8 @@ defmodule Barlix.ITF do
 
   defp interleave(digits) when Integer.is_even(length(digits)) do
     encoded =
-      Enum.chunk(digits, 2)
+      digits
+      |> Enum.chunk_every(2)
       |> Enum.map(fn chunk ->
         Enum.map(chunk, &encode_digit/1)
         |> Enum.map(&String.to_charlist/1)

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Barlix.Mixfile do
     [
       app: :barlix,
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.4",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: "Barcode generator",
@@ -25,11 +25,11 @@ defmodule Barlix.Mixfile do
   defp deps do
     [
       {:png, "~> 0.1"},
-      {:ex_doc, "~> 0.14", only: :dev},
+      {:ex_doc, "~> 0.20.2", only: :dev},
       {:mix_test_watch, "~> 0.2", only: :dev},
       {:tempfile, "~> 0.1.0", only: :test},
-      {:excheck, "~> 0.5", only: :test},
-      {:triq, github: "triqng/triq", only: :test}
+      {:excheck, "~> 0.6.0", only: :test},
+      {:triq, "~> 1.3", only: :test},
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Barlix.Mixfile do
     [
       app: :barlix,
       version: @version,
-      elixir: "~> 1.4",
+      elixir: "~> 1.5",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: "Barcode generator",

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,13 @@
-%{"earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "excheck": {:hex, :excheck, "0.5.3", "7326a29cc5fdb6900e66dac205a6a70cc994e2fe037d39136817d7dab13cdabf", [:mix], []},
+%{
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "excheck": {:hex, :excheck, "0.6.0", "f8595a8ac2c0abc0d060c1a4fce7d26f41574543366a52d5f3c84de30a69747b", [:mix], [], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "png": {:hex, :png, "0.1.1", "57eeab907d4c2b78d4c3803bc355af025248db9ebd612e4275c3cab65b809171", [:rebar], []},
   "tempfile": {:hex, :tempfile, "0.1.0", "2964afa1f653d133c61a818c84bb1b3c1a9c8e2f9f8489accb2e9c68cd0c1688", [:mix], []},
-  "triq": {:git, "https://github.com/triqng/triq.git", "2c497398e020e06db8496f1d89f12481cc5adab9", []}}
+  "triq": {:hex, :triq, "1.3.0", "d9ed60f3cd2b6bacbb721bc9873e67e07b02e5b97c63d40db35b12670a7f1bf4", [:rebar3], [], "hexpm"},
+}


### PR DESCRIPTION
- bump dependencies to eliminate warnings on newer Elixir
- include `triq` dependency from hex (not github)
- remove deprecation warning for `Enum.chunk` in favor of `Enum.chunk_every`
- fix minor typo
- bump version

Test ran successful on my machine on OTP22/Elixir 1.8, though emitting two warnings. I will check Travis...

Please review, merge (if fine) and publish. I did bump the version as well. 

Thanks @ananthakumaran 