### PR TITLE
Add UPC-E

### DIFF
--- a/lib/barlix.ex
+++ b/lib/barlix.ex
@@ -18,6 +18,7 @@ defmodule Barlix do
   * `Barlix.Code128`
   * `Barlix.ITF`
   * `Barlix.EAN13`
+  * `Barlix.UPCE`
 
   ## Renderers
 

--- a/lib/barlix/ean13.ex
+++ b/lib/barlix/ean13.ex
@@ -1,6 +1,4 @@
 defmodule Barlix.EAN13 do
-  require Integer
-  use Bitwise, only_operators: true
   import Integer, only: [mod: 2]
 
   @moduledoc """

--- a/lib/barlix/upce.ex
+++ b/lib/barlix/upce.ex
@@ -1,0 +1,172 @@
+defmodule Barlix.UPCE do
+  @moduledoc """
+  Implements [UPC-E](https://en.wikipedia.org/wiki/Universal_Product_Code#UPC-E).
+  """
+
+  @doc """
+  Encodes the given value using UPC-E. The given code is validated first.
+
+  ## Examples
+
+      iex> Barlix.UPCE.encode("04252614")
+      {:ok, {:D1, [
+        1, 0, 1,
+        0, 0, 1, 1, 1, 0, 1,
+        0, 0, 1, 0, 0, 1, 1,
+        0, 1, 1, 1, 0, 0, 1,
+        0, 0, 1, 1, 0, 1, 1,
+        0, 1, 0, 1, 1, 1, 1,
+        0, 0, 1, 1, 0, 0, 1,
+        0, 1, 0, 1, 0, 1
+      ]}}
+
+      iex> Barlix.UPCE.encode("123456")
+      {:error, "expected a string with exactly 8 chars, received 6 chars instead"}
+
+      iex> Barlix.UPCE.encode("06543214")
+      {:error, "validation failed: expected checksum digit 7 but received 4"}
+
+  """
+  @spec encode(String.t()) :: {:error, String.t()} | {:ok, Barlix.code()}
+  def encode(value) do
+    with {:ok, values} <- validate(value) do
+      {:ok, get_code(values)}
+    end
+  end
+
+  @doc """
+  Accepts the same arguments as `encode/1` but raises on error.
+  """
+  @spec encode!(String.t()) :: Barlix.code() | no_return
+  def encode!(value) do
+    case encode(value) do
+      {:ok, code} -> code
+      {:error, error} -> raise Barlix.Error, error
+    end
+  end
+
+  @doc """
+  Validate an UPC-E code.
+
+  ## Examples
+
+      iex> Barlix.UPCE.validate("04252614")
+      {:ok, [0, 4, 2, 5, 2, 6, 1, 4]}
+
+      iex> Barlix.UPCE.validate("123456789")
+      {:error, "expected a string with exactly 8 chars, received 9 chars instead"}
+
+      iex> Barlix.UPCE.validate("16543217")
+      {:error, "validation failed: expected checksum digit 4 but received 7"}
+
+      iex> Barlix.UPCE.validate(123)
+      {:error, "unexpected input"}
+  """
+  @spec validate(String.t()) :: {:ok, [non_neg_integer()]} | {:error, String.t()}
+  def validate(upc_e) when is_binary(upc_e) and byte_size(upc_e) == 8 do
+    if String.match?(upc_e, ~r/^\d{8}$/) do
+      with {:ok, _ean13_values} <-
+             upc_e
+             |> to_ean13()
+             |> Barlix.EAN13.validate() do
+        {:ok,
+         upc_e
+         |> String.split("", trim: true)
+         |> Enum.map(&String.to_integer/1)}
+      end
+    else
+      {:error, "validation failed, string must only contain digits"}
+    end
+  end
+
+  def validate(s) when is_binary(s) do
+    {:error, "expected a string with exactly 8 chars, received #{String.length(s)} chars instead"}
+  end
+
+  def validate(_), do: {:error, "unexpected input"}
+
+  defp to_ean13(upc_e) do
+    case upc_e do
+      <<system, manufacturer::binary-size(2), product::binary-size(3), "0", check_digit>> ->
+        <<"0", system, manufacturer::binary, "00000", product::binary, check_digit>>
+
+      <<system, manufacturer::binary-size(2), product::binary-size(3), "1", check_digit>> ->
+        <<"0", system, manufacturer::binary, "10000", product::binary, check_digit>>
+
+      <<system, manufacturer::binary-size(2), product::binary-size(3), "2", check_digit>> ->
+        <<"0", system, manufacturer::binary, "20000", product::binary, check_digit>>
+
+      <<system, manufacturer::binary-size(3), product::binary-size(2), "3", check_digit>> ->
+        <<"0", system, manufacturer::binary, "00000", product::binary, check_digit>>
+
+      <<system, manufacturer::binary-size(4), product, "4", check_digit>> ->
+        <<"0", system, manufacturer::binary, "00000", product, check_digit>>
+
+      <<system, manufacturer::binary-size(5), product, check_digit>> ->
+        <<"0", system, manufacturer::binary, "0000", product, check_digit>>
+    end
+  end
+
+  defp get_code(values) do
+    {[number_system | digits], [check_digit]} = Enum.split(values, 7)
+
+    encoded_digits =
+      digits
+      |> Enum.zip(parity_pattern(check_digit, number_system))
+      |> Enum.map(fn {digit, encoding_fun} -> encoding_fun.(digit) end)
+
+    {:D1, List.flatten([start_guard(), encoded_digits, end_guard()])}
+  end
+
+  defp parity_pattern(check_digit, number_system)
+
+  defp parity_pattern(0, 0), do: [&even/1, &even/1, &even/1, &odd/1, &odd/1, &odd/1]
+  defp parity_pattern(1, 0), do: [&even/1, &even/1, &odd/1, &even/1, &odd/1, &odd/1]
+  defp parity_pattern(2, 0), do: [&even/1, &even/1, &odd/1, &odd/1, &even/1, &odd/1]
+  defp parity_pattern(3, 0), do: [&even/1, &even/1, &odd/1, &odd/1, &odd/1, &even/1]
+  defp parity_pattern(4, 0), do: [&even/1, &odd/1, &even/1, &even/1, &odd/1, &odd/1]
+  defp parity_pattern(5, 0), do: [&even/1, &odd/1, &odd/1, &even/1, &even/1, &odd/1]
+  defp parity_pattern(6, 0), do: [&even/1, &odd/1, &odd/1, &odd/1, &even/1, &even/1]
+  defp parity_pattern(7, 0), do: [&even/1, &odd/1, &even/1, &odd/1, &even/1, &odd/1]
+  defp parity_pattern(8, 0), do: [&even/1, &odd/1, &even/1, &odd/1, &odd/1, &even/1]
+  defp parity_pattern(9, 0), do: [&even/1, &odd/1, &odd/1, &even/1, &odd/1, &even/1]
+
+  defp parity_pattern(0, 1), do: [&odd/1, &odd/1, &odd/1, &even/1, &even/1, &even/1]
+  defp parity_pattern(1, 1), do: [&odd/1, &odd/1, &even/1, &odd/1, &even/1, &even/1]
+  defp parity_pattern(2, 1), do: [&odd/1, &odd/1, &even/1, &even/1, &odd/1, &even/1]
+  defp parity_pattern(3, 1), do: [&odd/1, &odd/1, &even/1, &even/1, &even/1, &odd/1]
+  defp parity_pattern(4, 1), do: [&odd/1, &even/1, &odd/1, &odd/1, &even/1, &even/1]
+  defp parity_pattern(5, 1), do: [&odd/1, &even/1, &even/1, &odd/1, &odd/1, &even/1]
+  defp parity_pattern(6, 1), do: [&odd/1, &even/1, &even/1, &even/1, &odd/1, &odd/1]
+  defp parity_pattern(7, 1), do: [&odd/1, &even/1, &odd/1, &even/1, &odd/1, &even/1]
+  defp parity_pattern(8, 1), do: [&odd/1, &even/1, &odd/1, &even/1, &even/1, &odd/1]
+  defp parity_pattern(9, 1), do: [&odd/1, &even/1, &even/1, &odd/1, &even/1, &odd/1]
+
+  # Encoding tables
+
+  defp start_guard, do: [1, 0, 1]
+
+  defp odd(0), do: [0, 0, 0, 1, 1, 0, 1]
+  defp odd(1), do: [0, 0, 1, 1, 0, 0, 1]
+  defp odd(2), do: [0, 0, 1, 0, 0, 1, 1]
+  defp odd(3), do: [0, 1, 1, 1, 1, 0, 1]
+  defp odd(4), do: [0, 1, 0, 0, 0, 1, 1]
+  defp odd(5), do: [0, 1, 1, 0, 0, 0, 1]
+  defp odd(6), do: [0, 1, 0, 1, 1, 1, 1]
+  defp odd(7), do: [0, 1, 1, 1, 0, 1, 1]
+  defp odd(8), do: [0, 1, 1, 0, 1, 1, 1]
+  defp odd(9), do: [0, 0, 0, 1, 0, 1, 1]
+
+  defp even(0), do: [0, 1, 0, 0, 1, 1, 1]
+  defp even(1), do: [0, 1, 1, 0, 0, 1, 1]
+  defp even(2), do: [0, 0, 1, 1, 0, 1, 1]
+  defp even(3), do: [0, 1, 0, 0, 0, 0, 1]
+  defp even(4), do: [0, 0, 1, 1, 1, 0, 1]
+  defp even(5), do: [0, 1, 1, 1, 0, 0, 1]
+  defp even(6), do: [0, 0, 0, 0, 1, 0, 1]
+  defp even(7), do: [0, 0, 1, 0, 0, 0, 1]
+  defp even(8), do: [0, 0, 0, 1, 0, 0, 1]
+  defp even(9), do: [0, 0, 1, 0, 1, 1, 1]
+
+  defp end_guard, do: [0, 1, 0, 1, 0, 1]
+end

--- a/test/upce_test.exs
+++ b/test/upce_test.exs
@@ -1,0 +1,85 @@
+defmodule Barlix.UPCETest do
+  use ExUnit.Case, async: true
+
+  import TestUtils
+
+  alias Barlix.UPCE
+
+  doctest Barlix.UPCE
+
+  describe "encode/1" do
+    test "for valid number, return code" do
+      [
+        {"06543217",
+         "101" <>
+           "0000101" <>
+           "0110001" <>
+           "0011101" <>
+           "0111101" <>
+           "0011011" <>
+           "0011001" <>
+           "010101"},
+        {"07811403",
+         "101" <>
+           "0010001" <>
+           "0001001" <>
+           "0011001" <>
+           "0011001" <>
+           "0100011" <>
+           "0100111" <>
+           "010101"},
+        {"07235748",
+         "101" <>
+           "0010001" <>
+           "0010011" <>
+           "0100001" <>
+           "0110001" <>
+           "0111011" <>
+           "0011101" <>
+           "010101"}
+      ]
+      |> Enum.each(fn {i, e} ->
+        expected = s_to_l(e)
+
+        assert UPCE.encode!(i) == expected
+      end)
+    end
+
+    test "for invalid number, return error" do
+      assert_raise Barlix.Error, fn ->
+        UPCE.encode!("123456789")
+      end
+    end
+  end
+
+  describe "validate/1" do
+    test "for valid number, return :ok" do
+      assert UPCE.validate("07811403") == {:ok, [0, 7, 8, 1, 1, 4, 0, 3]}
+      assert UPCE.validate("07235748") == {:ok, [0, 7, 2, 3, 5, 7, 4, 8]}
+    end
+
+    test "for invalid number, return error" do
+      assert UPCE.validate("04252617") ==
+               {:error, "validation failed: expected checksum digit 4 but received 7"}
+    end
+
+    test "for wrong input length, return error" do
+      assert UPCE.validate("59012341234509876") ==
+               {:error, "expected a string with exactly 8 chars, received 17 chars instead"}
+
+      assert UPCE.validate("5901") ==
+               {:error, "expected a string with exactly 8 chars, received 4 chars instead"}
+    end
+
+    test "for wrong string, return error" do
+      assert UPCE.validate("0425x614") ==
+               {:error, "validation failed, string must only contain digits"}
+    end
+
+    test "for other wrong input, return error" do
+      assert UPCE.validate(nil) == {:error, "unexpected input"}
+      assert UPCE.validate([]) == {:error, "unexpected input"}
+      assert UPCE.validate(%{}) == {:error, "unexpected input"}
+    end
+  end
+end


### PR DESCRIPTION
- ~Add recent Elixir versions to CI~ (already merged)
- Fix a compiler warning in `Barlix.EAN13`
- Add support for [UPC-E](https://en.wikipedia.org/wiki/Universal_Product_Code#UPC-E), building on the EAN-13 implementation