### PR TITLE
fix: compiler deprecation warning re: `List.zip/1`

### DIFF
--- a/lib/barlix/itf.ex
+++ b/lib/barlix/itf.ex
@@ -62,7 +62,7 @@ defmodule Barlix.ITF do
       |> Enum.map(fn chunk ->
         Enum.map(chunk, &encode_digit/1)
         |> Enum.map(&String.to_charlist/1)
-        |> List.zip()
+        |> Enum.zip()
         |> chunks_to_bars
       end)
 


### PR DESCRIPTION
Using Elixir v1.18.4

```console
$ mix deps.compile barlix
==> barlix
Compiling 12 files (.ex)
    warning: List.zip/1 is deprecated. Use Enum.zip/1 instead
    │
 65 │         |> List.zip()
    │                 ~
    │
    └─ lib/barlix/itf.ex:65:17: Barlix.ITF.interleave/1
```